### PR TITLE
compiler warning about reloadDays

### DIFF
--- a/Classes/StatisticsViewController.h
+++ b/Classes/StatisticsViewController.h
@@ -35,6 +35,7 @@
 @property (nonatomic, retain) UIPageControl *pageControl;
 @property (retain) UIPickerView *datePicker;
 
+- (void)reloadDays;
 - (void)reload;
 - (void)updateGraphModeButton;
 


### PR DESCRIPTION
Declare - (void)reloadDays; to get rid of compiler warning.
