### PR TITLE
Allow reviews to be downloaded in the background

### DIFF
--- a/Classes/ReviewManager.h
+++ b/Classes/ReviewManager.h
@@ -25,6 +25,8 @@
 	NSMutableArray *storeInfos;
 	NSDateFormatter *defaultDateFormatter;
 	NSDate *downloadDate;
+
+	UIBackgroundTaskIdentifier bgTaskId;
 }
 
 + (ReviewManager*) sharedManager;


### PR DESCRIPTION
This allows you to hit the download button, leave the app, and the reviews will be there when you get back.
