### PR TITLE
Enable file sharing on application.

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -35,5 +35,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
This allows faster exportation of files through iTunes' drag and drop interface. It sure beats clicking all those links.
