### PR TITLE
logout after payments data was downloaded

### DIFF
--- a/Classes/ReportDownloadOperation.m
+++ b/Classes/ReportDownloadOperation.m
@@ -480,6 +480,18 @@
 					NSString *additionalPaymentsPage = [[[NSString alloc] initWithData:additionalPaymentsPageData encoding:NSUTF8StringEncoding] autorelease];
 					[self parsePaymentsPage:additionalPaymentsPage inAccount:account vendorID:additionalVendorOption];
 				}
+        
+        NSScanner *logoutFormScanner = [NSScanner scannerWithString:paymentsPage];
+        NSString *signoutFormAction = nil;
+				[logoutFormScanner scanUpToString:@"<form name=\"signOutForm\"" intoString:NULL];
+				[logoutFormScanner scanUpToString:@"action=\"" intoString:NULL];
+				if ([logoutFormScanner scanString:@"action=\"" intoString:NULL]) {
+					[logoutFormScanner scanUpToString:@"\"" intoString:&signoutFormAction];
+          
+          NSURL *logoutURL = [NSURL URLWithString:[ittsBaseURL stringByAppendingString:signoutFormAction]];
+          NSError *logoutPageError = nil;
+          [NSURLConnection sendSynchronousRequest:[NSURLRequest requestWithURL:logoutURL] returningResponse:nil error:&logoutPageError];
+        }
 			}
 		}
 	}


### PR DESCRIPTION
the cookies cleanup fix for issue #131 wasn't enough. 

I've added a logout url request after the payments data was downloaded to avoid payments and sale reports to appear in the wrong account.

Tested with my two accounts and looks it's working well now.
