### PR TITLE
Fixes Issue 150

### DIFF
--- a/Classes/Report.m
+++ b/Classes/Report.m
@@ -362,6 +362,10 @@
 	for (Transaction *transaction in self.transactions) {
 		NSString *type = transaction.type;
 		NSString *promoType = transaction.promoType;
+		if(promoType != nil) {
+			promoType = [promoType stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+			if([promoType isEqualToString:@""])promoType = nil;
+		}
 		NSString *combinedType = (promoType != nil) ? [NSString stringWithFormat:@"%@.%@", type, promoType] : type;
 		if (![paidTransactionTypes containsObject:combinedType]) {
 			continue;


### PR DESCRIPTION
Fixes Issue #150: In app purchases (and other non purchase types) displaying "0" incorrectly in the report detail view.

Looks like the NSString promoType would sometimes pull in non-printing characters which would make the next line checking if it was nil to pass over in app purchases incorrectly.

I added a quick whitespaceAndNewlineCharacterSet trim to the string and then a check to see if it was @"" and if it was, set to nil.
