### PR TITLE
Duplicate weekly reports issue fix 

### DIFF
--- a/Classes/Report.m
+++ b/Classes/Report.m
@@ -195,19 +195,36 @@
 		if (platform) {
 			product.platform = platform;
 		}
-		
+
 		if (!report) {
-			if (isWeeklyReport) {
-				report = [NSEntityDescription insertNewObjectForEntityForName:@"WeeklyReport" inManagedObjectContext:moc];
-				[(WeeklyReport *)report setEndDate:endDate];
-				[(WeeklyReport *)report setAccount:account];
-			} else {
-				report = [NSEntityDescription insertNewObjectForEntityForName:@"DailyReport" inManagedObjectContext:moc];
-				[(DailyReport *)report setAccount:account];
-			}
-			report.startDate = beginDate;
-		}
-		[[report mutableSetValueForKey:@"transactions"] addObject:transaction];
+      NSFetchRequest *existingReportsFetchRequest = [[[NSFetchRequest alloc] init] autorelease];
+      if (isWeeklyReport) {
+        [existingReportsFetchRequest setEntity:[NSEntityDescription entityForName:@"WeeklyReport" inManagedObjectContext:moc]];
+        [existingReportsFetchRequest setPredicate:[NSPredicate predicateWithFormat:@"account == %@ AND endDate == %@", account, endDate]];
+      } else {
+        [existingReportsFetchRequest setEntity:[NSEntityDescription entityForName:@"DailyReport" inManagedObjectContext:moc]];
+        [existingReportsFetchRequest setPredicate:[NSPredicate predicateWithFormat:@"account == %@ AND startDate == %@", account, endDate]];
+      }
+      
+      NSArray *existingReports = [moc executeFetchRequest:existingReportsFetchRequest error:NULL];
+
+      // in case there's already a report with the same date, skip this report
+      if ([existingReports count]!=0) {
+        return nil;
+      }
+
+      if (isWeeklyReport) {
+        report = [NSEntityDescription insertNewObjectForEntityForName:@"WeeklyReport" inManagedObjectContext:moc];
+        [(WeeklyReport *)report setEndDate:endDate];
+        [(WeeklyReport *)report setAccount:account];
+      } else {
+        report = [NSEntityDescription insertNewObjectForEntityForName:@"DailyReport" inManagedObjectContext:moc];
+        [(DailyReport *)report setAccount:account];
+      }
+        report.startDate = beginDate;
+    }
+    [[report mutableSetValueForKey:@"transactions"] addObject:transaction];
+    
 	}
 	return report;
 }


### PR DESCRIPTION
Looks like there's a strange bug in itunes connect reporting tool, which causes the duplicated weekly reports (#177, #138)

Requesting a weekly report (on Sunday or early monday, before the sales generation is completed) will return the weekly report of the passing week. 

For example, this request will return the weekly report for 20120108:

`USERNAMETYPEOFREPORT=Sales&DATETYPE=Daily&REPORTTYPE=Summary&REPORTDATE=20120115`

this bug fix will prevent entering duplicated reports into the appsales db.
