### PR TITLE
Fixes issue where the popovers in the iPad fail to position correctly.

### DIFF
--- a/Classes/GraphView.h
+++ b/Classes/GraphView.h
@@ -87,6 +87,7 @@
 - (void)setSegmentValues:(NSArray *)values;
 - (void)setSegmentValues:(NSArray *)values label:(NSString *)labelText;
 - (UIView *)selectedBackgroundView;
+- (int)getStackHeight;
 
 @end
 

--- a/Classes/GraphView.m
+++ b/Classes/GraphView.m
@@ -173,7 +173,9 @@
 	for (NSNumber *barIndex in visibleBarViews) {
 		StackedBarView *view = [visibleBarViews objectForKey:barIndex];
 		if (view == barView) {
-			[self.delegate graphView:self didSelectBarAtIndex:[barIndex unsignedIntegerValue] withFrame:[self convertRect:view.frame fromView:view.superview]];
+      int stackHeight = [view getStackHeight];
+      CGRect stackRect = CGRectMake(barView.frame.origin.x, barView.frame.origin.y + (barView.frame.size.height - stackHeight), barView.frame.size.width, stackHeight);
+      [self.delegate graphView:self didSelectBarAtIndex:[barIndex unsignedIntegerValue] withFrame:[self convertRect:stackRect fromView:view.superview]];
 			break;
 		}
 	}
@@ -492,6 +494,16 @@
 		label.text = labelText;
 		label.frame = CGRectIntegral(CGRectMake(0, y - 15, self.bounds.size.width, 15));
 	}
+}
+
+- (int)getStackHeight
+{
+  int stackHeight = 0;
+  for (UIView *segmentView in segmentViews) {
+    stackHeight += segmentView.frame.size.height;
+  }
+  
+  return stackHeight;
 }
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event

--- a/Classes/SalesViewController.m
+++ b/Classes/SalesViewController.m
@@ -619,7 +619,7 @@
 		self.selectedReportPopover = [[[UIPopoverController alloc] initWithContentViewController:nav] autorelease];
 		self.selectedReportPopover.passthroughViews = [NSArray arrayWithObjects:self.graphView, nil];
 		
-		[self.selectedReportPopover presentPopoverFromRect:barFrame inView:self.graphView permittedArrowDirections:UIInterfaceOrientationIsPortrait(self.interfaceOrientation) ? UIPopoverArrowDirectionUp : UIPopoverArrowDirectionDown animated:YES];
+		[self.selectedReportPopover presentPopoverFromRect:barFrame inView:self.graphView permittedArrowDirections:UIPopoverArrowDirectionLeft | UIPopoverArrowDirectionRight animated:YES];
 	}
 }
 


### PR DESCRIPTION
The iPad always displayed the popovers on the dashboard kind of weird. Here, I'm calculating the height of the stack and positioning the popover controller left or right of that rect so that the arrow is positioned correctly.
