### PR TITLE
Fixed #234 Clicking month bar shows report that's off by one month

### DIFF
--- a/Classes/SalesViewController.m
+++ b/Classes/SalesViewController.m
@@ -239,20 +239,17 @@
 	for (Report *dailyReport in sortedDailyReports) {
 		NSDateComponents *dateComponents = [calendar components:NSYearCalendarUnit | NSMonthCalendarUnit fromDate:dailyReport.startDate];
 		if (!prevDateComponents || (dateComponents.month != prevDateComponents.month || dateComponents.year != prevDateComponents.year)) {
-			if (reportsInCurrentMonth) {
-				ReportCollection *monthCollection = [[[ReportCollection alloc] initWithReports:reportsInCurrentMonth] autorelease];
-				monthCollection.title = [monthFormatter stringFromDate:dailyReport.startDate];
-				[sortedCalendarMonthReports addObject:monthCollection];
-			}
+			// New month discovered. Make a new ReportCollection to gather all the daily reports in this month.
 			reportsInCurrentMonth = [NSMutableArray array];
+			[reportsInCurrentMonth addObject:dailyReport];
+			ReportCollection *monthCollection = [[[ReportCollection alloc] initWithReports:reportsInCurrentMonth] autorelease];
+			monthCollection.title = [monthFormatter stringFromDate:dailyReport.startDate];
+			[sortedCalendarMonthReports addObject:monthCollection];
+		} else {
+			// This report is from the same month as the previous report. Append the daily report to the existing collection.
+			[reportsInCurrentMonth addObject:dailyReport];
 		}
-		[reportsInCurrentMonth addObject:dailyReport];
 		prevDateComponents = dateComponents;
-	}
-	if ([reportsInCurrentMonth count] > 0) {
-		ReportCollection *monthCollection = [[[ReportCollection alloc] initWithReports:reportsInCurrentMonth] autorelease];
-		monthCollection.title = [monthFormatter stringFromDate:[monthCollection firstReport].startDate];
-		[sortedCalendarMonthReports addObject:monthCollection];
 	}
 	
 	// Group daily reports by fiscal month:


### PR DESCRIPTION
When I click the month of December 2012, the title of my report view is
January 2013. When I click the final month (currently January 2013), the
title is correct. The result is that the final two months in report view
have the same title.
