### PR TITLE
Fixes display of app name in report details in landscape 

### DIFF
--- a/Classes/ReportDetailEntryCell.m
+++ b/Classes/ReportDetailEntryCell.m
@@ -53,6 +53,7 @@
 		[barBackgroundView addSubview:percentageLabel];
 		
 		subtitleLabel = [[UILabel alloc] initWithFrame:CGRectMake(130, 24, 147, 12)];
+        subtitleLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
 		subtitleLabel.backgroundColor = [UIColor clearColor];
 		subtitleLabel.font = [UIFont systemFontOfSize:11.0];
 		subtitleLabel.textColor = [UIColor darkGrayColor];


### PR DESCRIPTION
Subtitle in table view cells for report details was missing a resizing mask to show correctly when shown in landscape.
