### PR TITLE
Moved the top of the graph view 64 pixels down on iOS 7...

### DIFF
--- a/Classes/SalesViewController.m
+++ b/Classes/SalesViewController.m
@@ -82,8 +82,10 @@
 	
 	BOOL iPad = ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad);
 	
+	CGFloat top = ([[UIDevice currentDevice].systemVersion floatValue] >= 7.0) ? 64 : 0;
+	
 	CGFloat graphHeight = iPad ? 450.0 : (self.view.bounds.size.height - 44.0) * 0.5;
-	self.graphView = [[[GraphView alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, graphHeight)] autorelease];
+	self.graphView = [[[GraphView alloc] initWithFrame:CGRectMake(0, top, self.view.bounds.size.width, graphHeight)] autorelease];
 	graphView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
 	graphView.delegate = self;
 	graphView.dataSource = self;


### PR DESCRIPTION
... to fix the partly hidden and therefore unreadable graph problematic.
