### PR TITLE
Adding buddybuild status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 #AppSales
 
 ---
+[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=565753b228898101003ae89e&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/565753b228898101003ae89e/build/latest)
 
 ***Announcement***
 


### PR DESCRIPTION
We really liked AppSales and wanted to offer you a free continuous integration system [(buddybuild)](buddybuild.com) to make sure that your app always works!

If this sounds like something that may be helpful, setup is really simple and we've already taken most of the steps for you…[here](https://dashboard.buddybuild.com/apps/565753b228898101003ae89e/build/latest) are the builds we've completed for AppSales so far.

![screen shot 2015-11-26 at 10 48 38 am](https://cloud.githubusercontent.com/assets/13876667/11429533/41c13e38-942e-11e5-92b4-4162500e61df.png)

To configure your builds and to to make sure we kick off a new build with every commit you make, simply login [here] (dashboard.buddybuild.com).

Finally, if you’d like to know the latest build status of your app directly from your repo page, we offer small status badges - like the one seen on the [flappyswift](https://github.com/fullstackio/FlappySwift) repo.

To help add these, we created this pull request by adding a couple of lines to the readme.

If you have any questions or would like to learn more about buddybuild, feel free to email team@buddybuild.com directly or use the Intercom button on the website.